### PR TITLE
Fix path issues when creating zip and installers

### DIFF
--- a/styrene/bundle.py
+++ b/styrene/bundle.py
@@ -720,7 +720,7 @@ class NativeBundle:
         )
         logger.info("Writing “%s”…", output_file_basename)
         output_file_path = os.path.join(output_dir, output_file_basename)
-        cmd = ["zip", "-Xq9r", output_file_path, os.path.curdir]
+        cmd = ["zip", "-Xq9r", os.path.abspath(output_file_path), os.path.curdir]
         subprocess.check_call(
             cmd,
             cwd=root,
@@ -855,7 +855,7 @@ class NativeBundle:
             shutil.copy(nsh_src_file_path, nsh_targ_file_path)
 
         subprocess.check_call(
-            ["makensis.exe", "-V3", "-INPUTCHARSET", "UTF8", nsi_file_path],
+            ["makensis.exe", "-V3", "-INPUTCHARSET", "UTF8", os.path.abspath(nsi_file_path)],
             cwd=output_dir,
         )
         installer_exe_path = os.path.join(output_dir, installer_exe_name)


### PR DESCRIPTION
I was trying to run the demo configuration with:

```
styrene -o gtk3 ./gtk3-example
```

(`-o gtk3` as per this [comment](https://github.com/achadwick/styrene/issues/18#issuecomment-317249088) on #18)

and I couldn't create the installer because NSIS couldn't find the the .nsi configuration file and zip couldn't create the output file (`gtk3/gtk3-....zip`). This is because these commands are executed with a CWD of the root of the distribution (`gtk3/gtk3-examples`), which means that we really need to go up a directory. We could have hard-coded the path to just go up a directory or two, but I thought using abspath would be more sustainable in the long term.

Not sure what kind of testing you'd like to perform since I couldn't find any unit tests to run.